### PR TITLE
Updated to jdk11, similar to Android Studio 4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV PATH "${PATH}:${ANDROID_HOME}/bin"
 
 RUN dpkg --add-architecture i386 && \
     apt-get update -yqq && \
-    apt-get install -y curl expect git libc6:i386 libgcc1:i386 libncurses5:i386 libstdc++6:i386 zlib1g:i386 openjdk-8-jdk wget unzip vim && \
+    apt-get install -y curl expect git libc6:i386 libgcc1:i386 libncurses5:i386 libstdc++6:i386 zlib1g:i386 openjdk-11-jdk wget unzip vim && \
     apt-get clean
 
 RUN groupadd android && useradd -d /opt/android-sdk-linux -g android android


### PR DESCRIPTION
Android studio now ships with jdk 11

https://developer.android.com/studio/releases#4.2-bundled-jdk-11