### PR TITLE
remove the need for privileged container

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Docker for Android SDK 30 with preinstalled build tools and emulator image
 
 - Interactive way
   ```bash
-  $ docker run -it --rm --privileged androidsdk/android-30:latest bash
+  $ docker run -it --rm --device=/dev/bus --net=host androidsdk/android-30:latest bash
   # check installed packages
   $ sdkmanager --list
   # create and run emulator


### PR DESCRIPTION
to access devices via adb from within the docker container.

Thanks to the information here: [http://marc.merlins.org/perso/linux/post_2018-12-20_Accessing-USB-Devices-In-Docker-_ttyUSB0_-dev-bus-usb-_-for-fastboot_-adb_-without-using-privileged.html](http://marc.merlins.org/perso/linux/post_2018-12-20_Accessing-USB-Devices-In-Docker-_ttyUSB0_-dev-bus-usb-_-for-fastboot_-adb_-without-using-privileged.html)

Verified on Ubuntu 20.10 with an Android 8 device, after authorization, e.g. installing an APK via `adb install test.apk` works just fine.

This is also true for the other versions, just not sure if a PR would be needed for all of them or if there is a central template.